### PR TITLE
feat: Add NetBox superuser creation task

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,9 @@ tags:
   - ipam
   - netbox
   - networking
-dependencies: {}
+dependencies:
+  "community.general": "*"
+  "community.postgresql": "*"
 
 repository: "https://github.com/pheus/ansible-collection-netbox"
 issues: "https://github.com/pheus/ansible-collection-netbox/issues"

--- a/roles/nb_install/README.md
+++ b/roles/nb_install/README.md
@@ -6,7 +6,7 @@ Installs and configures [NetBox](https://github.com/netbox-community/netbox) as 
 
 The role requires the following Ansible collections to be available:
 
-  - community.django
+  - community.general
   - community.postgres
 
 Additionally NetBox has some requirements for the targeting host:

--- a/roles/nb_install/defaults/main.yml
+++ b/roles/nb_install/defaults/main.yml
@@ -19,6 +19,18 @@ nb_install_netbox_secret_key: "{{ lookup('ansible.builtin.password',
   '/dev/null', chars=['ascii_letters', 'digits', '!@#$%^&*(-_=+)'],
   length=50, seed=inventory_hostname) }}"
 
+# NetBox (Django) superuser creation enabled
+nb_install_netbox_superuser_creation_enabled: true
+
+# NetBox superuser username
+nb_install_netbox_superuser_username: admin
+
+# NetBox superuser user email address
+nb_install_netbox_superuser_email: "admin@example.org"
+
+# NetBox superuser password
+# nb_install_netbox_superuser_password: "ADD A SUPERUSER PASSWORD"
+
 # NetBox system user
 nb_install_netbox_system_user: netbox
 

--- a/roles/nb_install/tasks/database.yml
+++ b/roles/nb_install/tasks/database.yml
@@ -32,6 +32,7 @@
     name: "{{ nb_install_database_name }}"
     owner: "{{ nb_install_database_user_name }}"
     state: present
+  register: __nb_install_database_create_result
   notify: netbox-upgrade-script
 
 - name: database | Verify database user can connect to database

--- a/roles/nb_install/tasks/main.yml
+++ b/roles/nb_install/tasks/main.yml
@@ -1,6 +1,19 @@
 ---
 # main tasks file for Ansible role pheus.netbox.nb_install
 
+- name: Ensure superuser (admin) password is provided
+  ansible.builtin.assert:
+    that:
+      - nb_install_netbox_superuser_password is defined
+      - nb_install_netbox_superuser_password | length > 0
+    fail_msg: |
+      The initial superuser (admin) account for NetBox requires a password.
+
+      Please set an password via "nb_isntall_netbox_superuser_password"
+      or disable the creation of the superuser via
+      "nb_install_netbox_superuser_creation_enabled".
+  when: nb_install_netbox_superuser_creation_enabled | bool
+
 - name: Include PostgreSQL database installation and preparation tasks
   ansible.builtin.include_tasks:
     file: database.yml
@@ -12,5 +25,10 @@
 - name: Include NetBox instance installation tasks
   ansible.builtin.include_tasks:
     file: netbox.yml
+
+- name: Include NetBox superuser installation tasks
+  ansible.builtin.include_tasks:
+    file: superuser.yml
+  when: nb_install_netbox_superuser_creation_enabled | bool
 
 ...

--- a/roles/nb_install/tasks/superuser.yml
+++ b/roles/nb_install/tasks/superuser.yml
@@ -1,0 +1,28 @@
+---
+# tasks file for NetBox superuser creation
+
+# Flush the Ansible handlers to enforce the execution of the upgrade script
+# before the creation of the superuser.
+- name: superuser | Ensure handlers are executed
+  ansible.builtin.meta:
+    flush_handlers
+
+- name: superuser | Create an initial NetBox admin (superuser)
+  become: true
+  community.general.django_manage:
+    command: >-
+      createsuperuser --noinput
+      --username={{ nb_install_netbox_superuser_username }}
+      --email={{ nb_install_netbox_superuser_email }}
+    project_path: "{{ nb_install_netbox_install_path }}/netbox"
+    virtualenv: "{{ nb_install_netbox_install_path }}/venv"
+  environment:
+    DJANGO_SUPERUSER_PASSWORD: "{{ nb_install_netbox_superuser_password }}"
+  when: >
+    nb_install_netbox_superuser_creation_enabled | bool
+    and __nb_install_database_create_result is defined
+    and __nb_install_database_create_result.changed | bool
+    and 'CREATE DATABASE' in
+    __nb_install_database_create_result.executed_commands[0]
+
+...


### PR DESCRIPTION
This task is not idempotent, therefore is can run only once after the database creation task.
Flushing the handler during play execution will not execute any handler after the remaining tasks. Therefore the flush needs to be called after all deployment tasks have been executed.
The flush is only needed for the createsuperuser task, because the database must be already configured. Hence, the createsuperuser task needs to be at the end.